### PR TITLE
Replace httptest::with_mock_API with with_mock_api

### DIFF
--- a/tests/testthat/test-fetch.R
+++ b/tests/testthat/test-fetch.R
@@ -8,7 +8,7 @@ test_that("fetchSeries object is as expected", {
   expect_equal(fetch_list$bad$xts_object, "Bad response, error")
 })
 
-httptest::with_mock_API({
+httptest::with_mock_api({
   test_that("fetchSeries mocked", {
     amzn <- fetchSeries(function_nm = "time_series_daily", symbol = "amzn", outputsize = "compact", datatype = "json")
     bad <- fetchSeries(function_nm = "time_series_daily", symbol = "mr_potato_head", outputsize = "compact", datatype = "json")


### PR DESCRIPTION
Three years ago, [several functions were renamed](https://enpiar.com/r/httptest/news/#other-big-changes-and-enhancements) in the `httptest` 3.0.0 release for consistency with `httr` and `testthat`. Function aliases with the old naming were kept to avoid breaking packages, but in the [upcoming `httptest` 4.0.0 release](https://github.com/nealrichardson/httptest/issues/53), these deprecated functions are being removed. This PR updates your package to use the functions that will remain in the 4.0.0 release.

We plan to submit the `httptest` update to CRAN at the end of January. To avoid any potential nastygrams from CRAN, it would be ideal if you can update your package on CRAN with this change before then. Thanks!